### PR TITLE
Update Neo CLI repository URL

### DIFF
--- a/docs/n3/node/cli/setup.md
+++ b/docs/n3/node/cli/setup.md
@@ -66,7 +66,7 @@ You can download and compile the Neo-CLI source directly from GitHub.
 
 ### Installing required files
 
-1. Git clone Neo-CLI source code from [GitHub][https://github.com/neo-project/neo/tree/master/src/Neo.CLI](https://github.com/neo-project/neo/tree/master/src/Neo.CLI) or using the following command:
+1. Git clone Neo-CLI source code from [GitHub](https://github.com/neo-project/neo/tree/master/src/Neo.CLI) or using the following command:
 
     ```
     git clone https://github.com/neo-project/neo-node.git

--- a/docs/n3/node/cli/setup.md
+++ b/docs/n3/node/cli/setup.md
@@ -23,7 +23,7 @@ The following table lists the minimum and recommended hardware requirements for 
 
 ## Installing Neo-CLI package
 
-1. Download the latest [Neo-CLI](https://github.com/neo-project/neo-cli/releases) package according to your operating system on GitHub and unzip it.
+1. Download the latest [Neo-CLI](https://github.com/neo-project/neo/releases) package according to your operating system on GitHub and unzip it.
 
 2. On Linux, install the LevelDB and SQLite3 dev packages. 
 
@@ -66,7 +66,7 @@ You can download and compile the Neo-CLI source directly from GitHub.
 
 ### Installing required files
 
-1. Git clone Neo-CLI source code from [GitHub](https://github.com/neo-project/neo-node) or using the following command:
+1. Git clone Neo-CLI source code from [GitHub][https://github.com/neo-project/neo/tree/master/src/Neo.CLI](https://github.com/neo-project/neo/tree/master/src/Neo.CLI) or using the following command:
 
     ```
     git clone https://github.com/neo-project/neo-node.git


### PR DESCRIPTION
The current Neo CLI repository URL points to an outdated repo, causing significant confusion for users attempting to download the latest version. Ideally, the entire document should be updated to reflect the new repository structure. For now, this commit fixes the URL to ensure users can download the correct version.